### PR TITLE
Terminate SAP process on file processing errors

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -70,6 +70,7 @@ internal class Program
                 string fileName = Path.GetFileName(file);
                 log.Info($"Обработка заявки: {fileName}. Начинаю извлечение данных из заявки.");
 
+                SapfirManager sapfir = null;
                 try
                 {
                     jsonManager = new JsonManager(file, true);
@@ -207,7 +208,7 @@ internal class Program
 
                     try
                     {
-                        SapfirManager sapfir = new SapfirManager(sapLogonPath);
+                        sapfir = new SapfirManager(sapLogonPath);
                         sapfir.LaunchSAP();
                         log.Info("SAP Logon успешно запущен.");
 
@@ -932,10 +933,15 @@ internal class Program
                         log.Error(ex, "Ошибка SAP");
                         throw;
                     }
+                    finally
+                    {
+                        sapfir?.KillSAP();
+                    }
                 }
                 catch (Exception ex)
                 {
                     log.Error($"Ошибка при обработке входного файла {fileName}. Переход к следующему файлу.");
+                    sapfir?.KillSAP();
                     jsonManager.SetValue("status", "ERROR");
                     jsonManager.SetValue("message", ex.Message);
                     jsonManager.SaveToFile(file);


### PR DESCRIPTION
## Summary
- Ensure `SapfirManager` is accessible for error handling within file processing loop
- Always kill SAP Logon after SAP operations and when handling exceptions

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b6ce80c8b88323ae8377ab38858bdf